### PR TITLE
split the size in the administrative section repository list

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -2789,6 +2789,7 @@ repos.stars = Stars
 repos.forks = Forks
 repos.issues = Issues
 repos.size = Size
+repos.lfssize = LFS Size
 
 packages.package_manage_panel = Package Management
 packages.total_size = Total Size: %s

--- a/templates/admin/repo/list.tmpl
+++ b/templates/admin/repo/list.tmpl
@@ -33,6 +33,10 @@
 							{{.locale.Tr "admin.repos.size"}}
 							{{SortArrow "size" "reversesize" $.SortType false}}
 						</th>
+						<th  data-sortt-asc="size" data-sortt-desc="reversesize">
+							{{.locale.Tr "admin.repos.lfssize"}}
+							{{SortArrow "size" "reversesize" $.SortType false}}
+						</th>
 						<th>{{.locale.Tr "admin.auths.updated"}}</th>
 						<th>{{.locale.Tr "admin.users.created"}}</th>
 						<th>{{.locale.Tr "admin.notices.op"}}</th>
@@ -80,7 +84,8 @@
 							<td>{{.NumStars}}</td>
 							<td>{{.NumForks}}</td>
 							<td>{{.NumIssues}}</td>
-							<td>{{FileSize .Size}}</td>
+							<td>{{FileSize .GitSize}}</td>
+							<td>{{FileSize .LFSSize}}</td>
 							<td>{{DateTime "short" .UpdatedUnix}}</td>
 							<td>{{DateTime "short" .CreatedUnix}}</td>
 							<td><a class="delete-button" href="" data-url="{{$.Link}}/delete?page={{$.Page.Paginater.Current}}&sort={{$.SortType}}" data-id="{{.ID}}" data-name="{{.Name}}">{{svg "octicon-trash"}}</a></td>


### PR DESCRIPTION
Added unconditional size split in the administrative section repository list
before: showed Size as total size .Size
now shows Size as git size .GitSize
and LFS Size as .LFSSize
![gitsize_and_lfssize_in_admin](https://github.com/a1012112796/gitea/assets/23313323/a1d0dff2-d9ab-4f37-b31c-bfd598fb710e)
